### PR TITLE
Trying to get things working with mps backend

### DIFF
--- a/SetupMacOS.md
+++ b/SetupMacOS.md
@@ -1,0 +1,24 @@
+# Running on MacOS
+
+## Install / Setup
+First had to comment PyTorch deps in [pyproject.toml](./pyproject.toml) and [requirements.txt](./requirements.txt) to get PyTorch nightly installed for MPS support per [Apple's MPS docs](https://developer.apple.com/metal/pytorch/).
+
+```
+uv venv
+source .venv/bin/activate
+uv pip install setuptools
+uv pip install -e . --no-build-isolation # Looks like flash attention support is CUDA only 
+uv pip install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+uv run python ./scripts/download_weights.py weights/
+uv run python ./demos/gradio_ui.py --model_dir weights/
+```
+
+## Device contraints
+
+Had to reduce the frame size and count due to resource constraints on my machine
+
+Here's the changes to the defaults that worked for me in Gradio.
+```
+width = 640   # Requires: width % 16 == 0
+height = 384  # Requires: height % 16 == 0
+frames = 49   # Requires: frames = (n * 6) + 1 where n is some integer

--- a/demos/cli.py
+++ b/demos/cli.py
@@ -21,9 +21,8 @@ from genmo.mochi_preview.pipelines import (
 pipeline = None
 model_dir_path = None
 lora_path = None
-num_gpus = torch.cuda.device_count()
+num_gpus = 1 if torch.backends.mps.is_available() else torch.cuda.device_count()
 cpu_offload = False
-
 
 def configure_model(model_dir_path_, lora_path_, cpu_offload_, fast_model_=False):
     global model_dir_path, lora_path, cpu_offload

--- a/demos/fine_tuner/encode_videos.py
+++ b/demos/fine_tuner/encode_videos.py
@@ -14,6 +14,7 @@ import genmo.mochi_preview.dit.joint_model.context_parallel as cp
 import genmo.mochi_preview.vae.cp_conv as cp_conv
 from genmo.lib.progress import get_new_progress_bar, progress_bar
 from genmo.lib.utils import Timer, save_video
+from genmo.lib.device_helper import autocast_device
 from genmo.mochi_preview.pipelines import DecoderModelFactory, EncoderModelFactory
 from genmo.mochi_preview.vae.models import add_fourier_features, decode_latents
 
@@ -59,7 +60,7 @@ def preprocess(ctx: GPUContext, vid_path: Path, shape: str, reconstruct: bool):
     video = cp.local_shard(video, dim=2)  # split along time dimension
 
     with torch.inference_mode():
-        with torch.autocast("cuda", dtype=torch.bfloat16):
+        with autocast_device(dtype=torch.bfloat16):
             ldist = ctx.encoder(video)
 
         print(f"{og_shape} -> {ldist.mean.shape}")

--- a/demos/fine_tuner/train.py
+++ b/demos/fine_tuner/train.py
@@ -28,6 +28,7 @@ torch.use_deterministic_algorithms(False)
 import genmo.mochi_preview.dit.joint_model.lora as lora
 from genmo.lib.progress import progress_bar
 from genmo.lib.utils import Timer, save_video
+from genmo.lib.device_helper import autocast_device
 from genmo.mochi_preview.vae.vae_stats import vae_latents_to_dit_latents
 from genmo.mochi_preview.pipelines import (
     DecoderModelFactory,
@@ -358,7 +359,7 @@ def main(config_path):
             z_sigma = (1 - sigma_bcthw) * z + sigma_bcthw * eps
             ut = z - eps
 
-        with torch.autocast("cuda", dtype=torch.bfloat16):
+        with autocast_device(dtype=torch.bfloat16):
             preds = model(
                 x=z_sigma,
                 sigma=sigma,

--- a/demos/test_encoder_decoder.py
+++ b/demos/test_encoder_decoder.py
@@ -7,6 +7,7 @@ from einops import rearrange
 from safetensors.torch import load_file
 
 from genmo.lib.utils import save_video
+from genmo.lib.device_helper import autocast_device
 from genmo.mochi_preview.pipelines import DecoderModelFactory, decode_latents_tiled_spatial
 from genmo.mochi_preview.vae.models import Encoder, add_fourier_features
 
@@ -61,7 +62,7 @@ def reconstruct(mochi_dir, video_path):
 
     # Encode video to latent
     with torch.inference_mode():
-        with torch.autocast("cuda", dtype=torch.bfloat16):
+        with autocast_device(dtype=torch.bfloat16):
             t0 = time.time()
             ldist = encoder(video)
             torch.cuda.synchronize()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     "ray>=2.37.0",
     "sentencepiece>=0.2.0",
     "setuptools>=75.2.0",
-    "torch>=2.4.1",
-    "torchvision>=0.19.1",
+    # "torch>=2.4.1",
+    # "torchvision>=0.19.1",
     "transformers>=4.45.2",
 ]
 
@@ -27,10 +27,10 @@ flash = [
     "flash-attn>=2.6.3"
 ]
 
-torchvision = [
-    "torchvision>=0.15.0",
-    "pyav>=13.1.0"
-]
+# torchvision = [
+#     "torchvision>=0.15.0",
+#     "pyav>=13.1.0"
+# ]
 
 [tool.ruff]
 # Allow lines to be as long as 120.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pyyaml>=6.0.2
 ray>=2.37.0
 sentencepiece>=0.2.0
 setuptools>=75.2.0
-torch>=2.4.1
+# torch>=2.4.1
 transformers>=4.45.2

--- a/src/genmo/lib/attn_imports.py
+++ b/src/genmo/lib/attn_imports.py
@@ -2,12 +2,9 @@ from contextlib import contextmanager
 
 import torch
 
-if torch.cuda.is_available():
-    try:
-        from flash_attn import flash_attn_varlen_func as flash_varlen_attn
-    except ImportError:
-        flash_varlen_attn = None
-else:
+try:
+    from flash_attn import flash_attn_varlen_func as flash_varlen_attn
+except ImportError:
     flash_varlen_attn = None
 
 try:

--- a/src/genmo/lib/attn_imports.py
+++ b/src/genmo/lib/attn_imports.py
@@ -2,10 +2,12 @@ from contextlib import contextmanager
 
 import torch
 
-
-try:
-    from flash_attn import flash_attn_varlen_func as flash_varlen_attn
-except ImportError:
+if torch.cuda.is_available():
+    try:
+        from flash_attn import flash_attn_varlen_func as flash_varlen_attn
+    except ImportError:
+        flash_varlen_attn = None
+else:
     flash_varlen_attn = None
 
 try:
@@ -17,7 +19,7 @@ from torch.nn.attention import SDPBackend, sdpa_kernel
 
 training_backends = [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]
 eval_backends = list(training_backends)
-if torch.cuda.get_device_properties(0).major >= 9.0:
+if torch.cuda.is_available() and torch.cuda.get_device_properties(0).major >= 9.0:
     # Enable fast CuDNN attention on Hopper.
     # This gives NaN on the backward pass for some reason,
     # so only use it for evaluation.

--- a/src/genmo/lib/device_helper.py
+++ b/src/genmo/lib/device_helper.py
@@ -1,0 +1,40 @@
+import torch
+from contextlib import contextmanager
+from functools import wraps
+
+def get_default_device():
+    """
+    Return the default device string.
+    """
+    if torch.backends.mps.is_available():
+        return "mps"
+    elif torch.cuda.is_available():
+        return "cuda"
+    else:
+        return "cpu"
+
+@contextmanager
+def autocast_device(**kwargs):
+    """
+    Context manager that wraps torch.autocast with a default device.
+    """
+    device = get_default_device()
+    with torch.autocast(device, **kwargs):
+        yield
+
+def with_autocast(func=None, **ac_kwargs):
+    """
+    Decorator that wraps a function call inside a torch.autocast context,
+    using the default device
+    """
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            device = get_default_device()
+            with torch.autocast(device, **ac_kwargs):
+                return fn(*args, **kwargs)
+        return wrapper
+    if func is None:
+        return decorator
+    else:
+        return decorator(func)

--- a/src/genmo/mochi_preview/dit/joint_model/asymm_models_joint.py
+++ b/src/genmo/mochi_preview/dit/joint_model/asymm_models_joint.py
@@ -10,6 +10,7 @@ from torch.nn.attention import sdpa_kernel
 
 import genmo.mochi_preview.dit.joint_model.context_parallel as cp
 from genmo.lib.attn_imports import flash_varlen_attn, sage_attn, sdpa_attn_ctx
+from genmo.lib.device_helper import with_autocast
 from genmo.mochi_preview.dit.joint_model.layers import (
     FeedForward,
     PatchEmbed,
@@ -34,7 +35,6 @@ from genmo.mochi_preview.dit.joint_model.utils import (
 
 COMPILE_FINAL_LAYER = os.environ.get("COMPILE_DIT") == "1"
 COMPILE_MMDIT_BLOCK = os.environ.get("COMPILE_DIT") == "1"
-
 
 def ck(fn, *args, enabled=True, **kwargs) -> torch.Tensor:
     if enabled:
@@ -184,7 +184,7 @@ class AsymmetricAttention(nn.Module):
         v = v.view(-1, num_heads, head_dim)
         return q, k, v
 
-    @torch.autocast("cuda", enabled=False)
+    @with_autocast(enabled=False)
     def flash_attention(self, q, k, v, cu_seqlens, max_seqlen_in_batch, total, local_dim):
         out: torch.Tensor = flash_varlen_attn(
             q, k, v,
@@ -207,7 +207,7 @@ class AsymmetricAttention(nn.Module):
             )
             return out
 
-    @torch.autocast("cuda", enabled=False)
+    @with_autocast(enabled=False)
     def sage_attention(self, q, k, v):
         return sage_attn(q, k, v, attn_mask=None, dropout_p=0.0, is_causal=False)
 

--- a/src/genmo/mochi_preview/dit/joint_model/rope_mixed.py
+++ b/src/genmo/mochi_preview/dit/joint_model/rope_mixed.py
@@ -3,6 +3,7 @@ import math
 
 import torch
 
+from genmo.lib.device_helper import autocast_device
 
 def centers(start: float, stop, num, dtype=None, device=None):
     """linspace through bin centers.
@@ -80,7 +81,7 @@ def compute_mixed_rotation(
         freqs_cos: [N, num_heads, num_freqs] - cosine components
         freqs_sin: [N, num_heads, num_freqs] - sine components
     """
-    with torch.autocast("cuda", enabled=False):
+    with autocast_device(enabled=False):
         assert freqs.ndim == 3
         freqs_sum = torch.einsum("Nd,dhf->Nhf", pos.to(freqs), freqs)
         freqs_cos = torch.cos(freqs_sum)

--- a/src/genmo/mochi_preview/pipelines.py
+++ b/src/genmo/mochi_preview/pipelines.py
@@ -418,6 +418,13 @@ def assert_eq(x, y, msg=None):
 
 
 def sample_model(device, dit, conditioning, **args):
+    # Check if we're running on MPS
+    is_mps = device.type == 'mps'
+    
+    # Use different clipping ranges based on device type
+    CLIP_RANGE = (-1e6, 1e6) if not is_mps else (-1e5, 1e5)
+    UPDATE_CLIP_RANGE = (-1e6, 1e6) if not is_mps else (-100.0, 100.0)
+
     random.seed(args["seed"])
     np.random.seed(args["seed"])
     torch.manual_seed(args["seed"])
@@ -483,7 +490,7 @@ def sample_model(device, dit, conditioning, **args):
         out_cond = out_cond.to(z)
         pred = out_uncond + cfg_scale * (out_cond - out_uncond)
         # Clip prediction to avoid explosion
-        pred = torch.clamp(pred, -1e6, 1e6)
+        pred = torch.clamp(pred, *CLIP_RANGE)
         return pred
 
     # Euler sampler w/ customizable sigma schedule & cfg scale
@@ -501,7 +508,7 @@ def sample_model(device, dit, conditioning, **args):
         # Add numerical stability to the update
         update = dsigma * pred
         update = torch.nan_to_num(update, nan=0.0, posinf=0.0, neginf=0.0)
-        z = torch.clamp(z + update, -1e6, 1e6)
+        z = torch.clamp(z + update, *UPDATE_CLIP_RANGE)
 
     z = z[:B] if cond_batched else z
     return dit_latents_to_vae_latents(z)

--- a/src/genmo/mochi_preview/pipelines.py
+++ b/src/genmo/mochi_preview/pipelines.py
@@ -40,6 +40,7 @@ from genmo.mochi_preview.vae.models import (
     decode_latents_tiled_spatial,
 )
 from genmo.mochi_preview.vae.vae_stats import dit_latents_to_vae_latents
+from genmo.lib.device_helper import autocast_device
 
 
 def load_to_cpu(p, weights_only=True):
@@ -70,6 +71,14 @@ def linear_quadratic_schedule(num_steps, threshold_noise, linear_steps=None):
 T5_MODEL = "google/t5-v1_1-xxl"
 MAX_T5_TOKEN_LENGTH = 256
 
+def get_torch_device(device_id=0):
+    # Prefer MPS if available; fallback order: MPS > CUDA > CPU.
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    elif torch.cuda.is_available():
+        return torch.device(f"cuda:{device_id}")
+    else:
+        return torch.device("cpu")
 
 def setup_fsdp_sync(model, device_id, *, param_dtype, auto_wrap_policy) -> FSDP:
     model = FSDP(
@@ -87,7 +96,10 @@ def setup_fsdp_sync(model, device_id, *, param_dtype, auto_wrap_policy) -> FSDP:
         sync_module_states=True,
         use_orig_params=True,
     )
-    torch.cuda.synchronize()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    elif torch.backends.mps.is_available():
+        torch.mps.synchronize()
     return model
 
 
@@ -124,7 +136,7 @@ class T5ModelFactory(ModelFactory):
                 ),
             )
         elif isinstance(device_id, int):
-            model = model.to(torch.device(f"cuda:{device_id}"))  # type: ignore
+            model = model.to(get_torch_device(device_id))  # type: ignore
         return model.eval()
 
 
@@ -243,7 +255,7 @@ class DitModelFactory(ModelFactory):
                 ),
             )
         elif isinstance(device_id, int):
-            model = model.to(torch.device(f"cuda:{device_id}"))
+            model = model.to(get_torch_device(device_id))
         return model.eval()
 
 
@@ -272,7 +284,7 @@ class DecoderModelFactory(ModelFactory):
         # VAE is not FSDP-wrapped
         state_dict = load_file(self.kwargs["model_path"])
         decoder.load_state_dict(state_dict, strict=True)
-        device = torch.device(f"cuda:{device_id}") if isinstance(device_id, int) else "cpu"
+        device = get_torch_device(device_id)
         decoder.eval().to(device)
         return decoder
 
@@ -303,7 +315,7 @@ class EncoderModelFactory(ModelFactory):
         )
         state_dict = load_file(self.kwargs["model_path"])
         encoder.load_state_dict(state_dict, strict=True)
-        device = torch.device(f"cuda:{device_id}") if isinstance(device_id, int) else "cpu"
+        device = get_torch_device(device_id)
         encoder.eval().to(device)
         return encoder
 
@@ -453,18 +465,26 @@ def sample_model(device, dit, conditioning, **args):
 
     def model_fn(*, z, sigma, cfg_scale):
         if cond_batched:
-            with torch.autocast("cuda", dtype=torch.bfloat16):
+            with autocast_device(dtype=torch.bfloat16):
                 out = dit(z, sigma, **cond_batched)
             out_cond, out_uncond = torch.chunk(out, chunks=2, dim=0)
         else:
             nonlocal cond_text, cond_null
-            with torch.autocast("cuda", dtype=torch.bfloat16):
+            with autocast_device(dtype=torch.bfloat16):
                 out_cond = dit(z, sigma, **cond_text)
                 out_uncond = dit(z, sigma, **cond_null)
+        
+        # Ensure outputs are finite and in a reasonable range
+        out_cond = torch.nan_to_num(out_cond, nan=0.0, posinf=1.0, neginf=-1.0)
+        out_uncond = torch.nan_to_num(out_uncond, nan=0.0, posinf=1.0, neginf=-1.0)
+                
         assert out_cond.shape == out_uncond.shape
         out_uncond = out_uncond.to(z)
         out_cond = out_cond.to(z)
-        return out_uncond + cfg_scale * (out_cond - out_uncond)
+        pred = out_uncond + cfg_scale * (out_cond - out_uncond)
+        # Clip prediction to avoid explosion
+        pred = torch.clamp(pred, -1e6, 1e6)
+        return pred
 
     # Euler sampler w/ customizable sigma schedule & cfg scale
     for i in get_new_progress_bar(range(0, sample_steps), desc="Sampling"):
@@ -478,7 +498,10 @@ def sample_model(device, dit, conditioning, **args):
             cfg_scale=cfg_schedule[i],
         )
         assert pred.dtype == torch.float32
-        z = z + dsigma * pred
+        # Add numerical stability to the update
+        update = dsigma * pred
+        update = torch.nan_to_num(update, nan=0.0, posinf=0.0, neginf=0.0)
+        z = torch.clamp(z + update, -1e6, 1e6)
 
     z = z[:B] if cond_batched else z
     return dit_latents_to_vae_latents(z)
@@ -490,17 +513,16 @@ def move_to_device(model: nn.Module, target_device, *, enabled=True):
         yield
         return
 
-    og_device = next(model.parameters()).device
-    if og_device == target_device:
-        print(f"move_to_device is a no-op model is already on {target_device}")
-    else:
-        print(f"moving model from {og_device} -> {target_device}")
-
+    old_device = next(model.parameters()).device
+    # If target_device is a CUDA device but CUDA is not enabled, fallback to MPS if available.
+    if target_device.type == "cuda" and not torch.cuda.is_available() and torch.backends.mps.is_available():
+        target_device = torch.device("mps")
+    print(f"moving model from {old_device} -> {target_device}")
     model.to(target_device)
     yield
-    if og_device != target_device:
-        print(f"moving model from {target_device} -> {og_device}")
-    model.to(og_device)
+    if old_device != target_device:
+        print(f"moving model from {target_device} -> {old_device}")
+    model.to(old_device)
 
 
 def t5_tokenizer(model_dir=None):
@@ -520,7 +542,7 @@ class MochiSingleGPUPipeline:
         fast_init=True,
         strict_load=True
     ):
-        self.device = torch.device("cuda:0")
+        self.device = get_torch_device()
         self.tokenizer = t5_tokenizer(text_encoder_factory.model_dir)
         t = Timer()
         self.cpu_offload = cpu_offload
@@ -643,6 +665,8 @@ class MochiMultiGPUPipeline:
         dit_factory: ModelFactory,
         decoder_factory: ModelFactory,
         world_size: int,
+        cpu_offload: bool = False,
+        **kwargs
     ):
         ray.init()
         RemoteClass = ray.remote(MultiGPUContext)

--- a/src/genmo/mochi_preview/vae/models.py
+++ b/src/genmo/mochi_preview/vae/models.py
@@ -9,10 +9,10 @@ from einops import rearrange
 
 import genmo.mochi_preview.dit.joint_model.context_parallel as cp
 from genmo.lib.progress import get_new_progress_bar
+from genmo.lib.device_helper import autocast_device
 from genmo.mochi_preview.vae.cp_conv import cp_pass_frames, gather_all_frames
 from genmo.mochi_preview.vae.latent_dist import LatentDistribution
 import genmo.mochi_preview.vae.cp_conv as cp_conv
-
 
 def cast_tuple(t, length=1):
     return t if isinstance(t, tuple) else ((t,) * length)
@@ -1015,7 +1015,7 @@ def decode_latents(decoder, z):
     assert z.ndim == 5
     cp_rank, cp_size = cp.get_cp_rank_size()
     z = z.tensor_split(cp_size, dim=2)[cp_rank]  # split along temporal dim
-    with torch.autocast("cuda", dtype=torch.bfloat16):
+    with autocast_device(dtype=torch.bfloat16):
         samples = decoder(z)
     samples = gather_all_frames(samples)
     return normalize_decoded_frames(samples)

--- a/src/genmo/mochi_preview/vae/models.py
+++ b/src/genmo/mochi_preview/vae/models.py
@@ -1015,6 +1015,11 @@ def decode_latents(decoder, z):
     assert z.ndim == 5
     cp_rank, cp_size = cp.get_cp_rank_size()
     z = z.tensor_split(cp_size, dim=2)[cp_rank]  # split along temporal dim
+    
+    # Add minimal MPS handling
+    if z.device.type == 'mps':
+        z = z.float()  # Ensure float32 precision
+    
     with autocast_device(dtype=torch.bfloat16):
         samples = decoder(z)
     samples = gather_all_frames(samples)


### PR DESCRIPTION
Took very naive attempt at getting this running wtih MPS. 

Notes on install are in [SetupMacOS.md](https://github.com/stephenhandley/mochi/blob/fef3193b27ba0448f2e3b861fd8e3a39e31b5ce3/SetupMacOS.md)

Changes basically revolved around removing hard-coded usage of `"cuda"` by testing for MPS support which is mostly contained in [device_helper.py](./src/genmo/lib/device_helper.py). I got a blank video at first and so added some clamping which looks to have mostly pushed things towards grid-based noise rather than it being blank.

Example of  128x128, 13 frames:
https://github.com/user-attachments/assets/9653aff2-0647-417b-b493-790cb6657ea0

# Notes

Running with the defaults Gradio launched, I ran into this error:
```
RuntimeError: Invalid buffer size: 88.60 GB
```
and later
```
[MPSNDArray initWithDevice:descriptor:isTextureBacked:] Error: total bytes of NDArray > 2**32 
```

Apparently MPS/Metal limits the size of arrays to 2^32 bytes (~4.2GB).

640 x 360 caused an error around height since it isn't evenly divisible by 16.
```
Input height (45) should be divisible by patch size (2).
```
360 / 8 = 45 which is not divisible by 2, so increased height to 384 and that worked.




